### PR TITLE
Added rinkeby key generation and address mapping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,20 @@
 import http from 'http'
-import { CryptoUtils, LoomProvider, Client, ClientEvent } from 'loom-js'
+import {
+  CryptoUtils,
+  LoomProvider,
+  Client,
+  ClientEvent,
+  LocalAddress,
+  Address,
+  Contracts,
+  NonceTxMiddleware,
+  SignedTxMiddleware
+} from 'loom-js'
 import { IEthRPCPayload } from 'loom-js/dist/loom-provider'
+import Web3 from 'web3'
+import { OfflineWeb3Signer } from 'loom-js/dist/solidity-helpers'
+
+const AddressMapper = Contracts.AddressMapper
 
 // Default chain id
 const chainId = process.env.CHAIN_ID || 'default'
@@ -12,9 +26,63 @@ const chainEndpoint = process.env.CHAIN_ENDPOINT || 'wss://plasma.dappchains.com
 const port = process.env.PORT || 8080
 
 // Initialize Client and LoomProvider
-const privateKey = CryptoUtils.generatePrivateKey()
-const client = new Client(chainId, `${chainEndpoint}/websocket`, `${chainEndpoint}/eth`)
-const loomProvider = new LoomProvider(client, privateKey)
+const privateKeyLoom = CryptoUtils.generatePrivateKey()
+const client = new Client(chainId, `${chainEndpoint}/websocket`, `${chainEndpoint}/queryws`)
+const loomPublicKey = CryptoUtils.publicKeyFromPrivateKey(privateKeyLoom)
+client.txMiddleware = [
+  new NonceTxMiddleware(loomPublicKey, client),
+  new SignedTxMiddleware(privateKeyLoom)
+]
+const loomProvider = new LoomProvider(client, privateKeyLoom)
+
+// create Rinkeby address
+
+const InfuraAPIkey = process.env.INFURA_API_KEY
+
+const privateKeyRinkeby = CryptoUtils.generatePrivateKey()
+const web3js = new Web3(`https://rinkeby.infura.io/v3/${InfuraAPIkey}`)
+const ownerAccount = web3js.eth.accounts.privateKeyToAccount('0x' + privateKeyRinkeby)
+web3js.eth.accounts.wallet.add(ownerAccount)
+
+const rinkebyAddress = ownerAccount.address
+
+// get Loom address
+
+const loomAddress = LocalAddress.fromPublicKey(loomPublicKey).toString()
+
+console.log(`Rinkeby address : ${rinkebyAddress}`)
+console.log(`Loom address : ${loomAddress}`)
+
+// mapping accounts
+
+const signer = new OfflineWeb3Signer(web3js, ownerAccount)
+
+async function mapAccounts(client, signer, ownerRinkebyAddress, ownerExtdevAddress) {
+  const ownerRinkebyAddr = Address.fromString(`eth:${ownerRinkebyAddress}`)
+  const ownerExtdevAddr = Address.fromString(`${client.chainId}:${ownerExtdevAddress}`)
+
+  let mapperContract
+  mapperContract = await AddressMapper.createAsync(client, ownerExtdevAddr)
+
+  try {
+    const mapping = await mapperContract.getMappingAsync(ownerExtdevAddr)
+    console.log(`${mapping.from.toString()} is already mapped to ${mapping.to.toString()}`)
+    return
+  } catch (err) {
+    // assume this means there is no mapping yet, need to fix loom-js not to throw in this case
+  }
+  console.log(`mapping ${ownerRinkebyAddr.toString()} to ${ownerExtdevAddr.toString()}`)
+
+  try {
+    await mapperContract.addIdentityMappingAsync(ownerExtdevAddr, ownerRinkebyAddr, signer)
+  } catch (err) {
+    console.log(err)
+  }
+
+  console.log(`Mapped ${ownerExtdevAddr} to ${ownerRinkebyAddr}`)
+}
+
+mapAccounts(client, signer, rinkebyAddress, loomAddress)
 
 // Used by Remix https://remix.ethereum.org
 loomProvider.addCustomMethod('net_listening', (payload: IEthRPCPayload) => true)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */


### PR DESCRIPTION
Problem :

The proxy generates a new Loom address that is used as sending address automatically in Remix, however this address is not mapped to a L1 address and therefore any call or transaction results in the following error : 
call to Lottery.manager errored: Invalid JSON RPC response: "loom error: failed to resolve account address: failed to map account eth:0x901c323DACa1EfB91C67beD6A795EDD7228B335f: [Address Mapper] failed to map address eth:0x901c323DACa1EfB91C67beD6A795EDD7228B335f: not found"

Proposed solution : 

Add a rinkeby key generation and a mapping of the addresses in the proxy script. This removes the error mentioned above and the user can make calls and transactions in Remix normally.

Additional comments : 
- I'm not familiar with TypeScript yet, so I had to remove the "noImplicitAny" rule to avoid compilation errors
- The script could be further improved by letting the user enter their own private keys for rinkeby and extdev, so that they can use those for testing purposes instead of the random ones generated by the script